### PR TITLE
Add trim command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.20.2
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.20.2
+      - image: circleci/golang:1.17.5
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.17.5
+      - image: cimg/go:1.20.2
     steps:
       - checkout
       - run:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,12 +25,15 @@ const (
 	DefaultSeparator = ` | `
 	// DefaultMetrics to capture when aggregating
 	DefaultMetrics = `(severity|white),(httpRequest.requestMethod|white),(httpRequest.status|green)`
+	// DefaultTrim is set to zero
+	DefaultTrim = "0"
 )
 
 func init() {
 	rootCmd.Flags().StringP("format", "f", "", "Supply a format string")
 	rootCmd.Flags().StringP("style", "s", "", "Supply a style of log")
 	rootCmd.Flags().StringP("separator", "p", "", "Separate fields by supplied character")
+	rootCmd.Flags().Int("trim", 0, "Supply an integer")
 }
 
 func parseFlag(cmd *cobra.Command, flag, defaultFlag string) string {
@@ -50,7 +53,7 @@ func parseStyle(style string) (tinj.Style, error) {
 	case `compose`:
 		return tinj.Compose, nil
 	}
-	return tinj.Tail, fmt.Errorf("--style %q not recognised.", style)
+	return tinj.Tail, fmt.Errorf("--style %q not recognised", style)
 }
 
 var rootCmd = &cobra.Command{
@@ -58,6 +61,7 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		format := parseFlag(cmd, "format", DefaultFormat)
 		separator := parseFlag(cmd, "separator", DefaultSeparator)
+		trim, _ := cmd.Flags().GetInt("trim")
 		style := parseFlag(cmd, "style", DefaultStyle)
 
 		info, err := os.Stdin.Stat()
@@ -79,7 +83,7 @@ var rootCmd = &cobra.Command{
 			fmt.Println("Try: tail, stern or compose")
 			return
 		}
-		tinj.ReadStdin(format, separator, lineStyle)
+		tinj.ReadStdin(format, separator, lineStyle, trim)
 	},
 }
 
@@ -98,7 +102,7 @@ var subCmd = &cobra.Command{
 		// Help Text
 		if info.Mode()&os.ModeCharDevice != 0 {
 			fmt.Println("The command is intended to work with pipes.")
-			fmt.Println("Usage: cat file.json | tinj")
+			fmt.Println("Usage: cat file.json | tinj count")
 			return
 		}
 		tinj.AggregateStdin(metrics, separator)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,8 +25,6 @@ const (
 	DefaultSeparator = ` | `
 	// DefaultMetrics to capture when aggregating
 	DefaultMetrics = `(severity|white),(httpRequest.requestMethod|white),(httpRequest.status|green)`
-	// DefaultTrim is set to zero
-	DefaultTrim = "0"
 )
 
 func init() {

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/go-bongo/go-dotaccess v0.0.0-20150208020959-ae070a2d2a38 h1:Lsa/FOkxWZMjwdb2SfZaQrfdiS7WF7hv3lhRqpVA+7I=
 github.com/go-bongo/go-dotaccess v0.0.0-20150208020959-ae070a2d2a38/go.mod h1:qN1bnlshxJYF58B+mdviLPf2sYHX99yec7pQVoEPJ2I=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
@@ -37,6 +38,7 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/formatter.go
+++ b/pkg/formatter.go
@@ -48,7 +48,7 @@ func CreateLineFormatter(fields []*Field, separator string, style Style) *LineFo
 }
 
 // ReadStdin streams lines from stdin
-func ReadStdin(format, separator string, style Style) {
+func ReadStdin(format, separator string, style Style, trim int) {
 	fields := ConstructFields(format)
 	lineFormatter := CreateLineFormatter(fields, separator, style)
 
@@ -59,14 +59,14 @@ func ReadStdin(format, separator string, style Style) {
 			// Exit? Exit on interrupt!
 			break
 		}
-		lineFormatter.Print(nextLine)
+		lineFormatter.Print(nextLine, trim)
 		nextLine = nil
 	}
 }
 
 // Print line with new format
-func (l *LineFormatter) Print(line []byte) {
-	prefix, line := l.normPrefix(line)
+func (l *LineFormatter) Print(line []byte, trim int) {
+	prefix, line := l.normPrefix(line, trim)
 	if prefix != nil {
 		colour := determineColor(prefix)
 		fmt.Printf("%v", colour(string(prefix)))
@@ -93,7 +93,8 @@ func (l *LineFormatter) Print(line []byte) {
 	fmt.Print("\n")
 }
 
-func (l *LineFormatter) normPrefix(line []byte) ([]byte, []byte) {
+func (l *LineFormatter) normPrefix(line []byte, trim int) ([]byte, []byte) {
+	line = line[trim:]
 	if (len(line) > 0) && (line[0] != '{') {
 		switch l.Style {
 		case Tail:


### PR DESCRIPTION
Added `--trim` flag to cut the first `n` characters, gets rid of the mess in some styles of logging.

### From this

```bash
$ cat samples/stern.json | go run . --style stern
travel-f75749647-254sz travel travel | INFO | Saving prediction for None-None actions: {'ticket-approved': 0}
travel-f75749647-254sz travel travel | INFO | 200 | method=POST url=/api/v1/<redacted> statusCode=200
travel-f75749647-jkrk7 travel travel | INFO | Saving prediction for None-None actions: {'ticket-approved': 1}
travel-f75749647-jkrk7 travel travel | INFO | 200 | method=POST url=/api/v1/<redacted> statusCode=200
travel-f75749647-254sz travel travel | INFO | Saving prediction for None-None actions: {'ticket-approved': 0}
```

### To this

```bash
$ cat samples/stern.json | go run . --style stern --trim 30
travel | INFO | Saving prediction for None-None actions: {'ticket-approved': 0}
travel | INFO | 200 | method=POST url=/api/v1/<redacted> statusCode=200
travel | INFO | Saving prediction for None-None actions: {'ticket-approved': 1}
travel | INFO | 200 | method=POST url=/api/v1/<redacted> statusCode=200
travel | INFO | Saving prediction for None-None actions: {'ticket-approved': 0}
```